### PR TITLE
feat: allow developers to bypass the docker build

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Build
       run: cargo build --all
     - name: Run tests
-      run: cargo test -- --test-threads=1
+      run: DOCKER_BUILD=1 cargo test
 
 
   fmt:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,12 +8,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - name: Install stable
-      run: rustup toolchain install stable
     - name: Install protoc
-      run: sudo apt-get install protobuf-compiler
+      run: sudo apt-get update -qqq && sudo apt-get install -y protobuf-compiler
+    - name: Install latest nightly
+      uses: actions-rs/toolchain@v1
+      with:
+          toolchain: stable
+          override: true
+          components: rustfmt, clippy
     - name: Build
-      run: cargo build --all
+      run: DOCKER_BUILD=1 cargo build --all
     - name: Run tests
       run: DOCKER_BUILD=1 cargo test
 

--- a/README.md
+++ b/README.md
@@ -10,8 +10,11 @@ Ensure that docker is installed on the machine where the tests need to be run.
 
 Then, run the following as usual.
 ```
-cargo test
+DOCKER_BUILD=1 cargo test
 ```
+
+Note that if you've already built the docker image and want to avoid this step,
+you can ignore the `DOCKER_BUILD` environment variable.
 
 ### Writing New Tests
 

--- a/README.md
+++ b/README.md
@@ -30,22 +30,21 @@ snippet.
 ```rust
 #[cfg(test)]
 mod test {
-    use testcontainers::clients;
-    use testcontainers::core::WaitFor;
-    use testcontainers::images::generic::GenericImage;
+    use crate::new_nym_client;
     #[tokio::test]
     async fn test_with_nym() {
-        let docker_client = clients::Cli::default();
-        let nym_ready_message = WaitFor::message_on_stderr("Client startup finished!");
-        let nym_dialer_image = GenericImage::new("nym", "latest")
-            .with_env_var("NYM_ID", "test_connection_dialer")
-            .with_wait_for(nym_ready_message.clone())
-            .with_exposed_port(1977);
-        let dialer_container = docker_client.run(nym_dialer_image);
-        let dialer_port = dialer_container.get_host_port_ipv4(1977);
-        let dialer_uri = format!("ws://0.0.0.0:{dialer_port}");
+
+        let nym_id = "test_transport_connection_dialer";
+        #[allow(unused)]
+        let dialer_uri: String;
+        new_nym_client!(nym_id, dialer_uri);
+        todo!("Now you can use the dialer_uri to make requests.")
     }
 }
 ```
 
 One can create as many of these as needed, limited only by the server resources.
+
+**NOTE**: When using a URI for connections, ensure that you're prefixing the
+URI with the `ws://` protocol type, otherwise the nym client assumes http and
+crashes unceremoniously.

--- a/build.rs
+++ b/build.rs
@@ -1,17 +1,21 @@
+use std::env;
 use std::process::Command;
 fn main() {
     println!("cargo:rerun-if-changed=Dockerfile.nym");
-    let output = Command::new("docker")
-        .arg("build")
-        .arg("-t")
-        .arg("nym:latest")
-        .arg("-f")
-        .arg("./Dockerfile.nym")
-        .arg(".")
-        .output()
-        .expect("ERROR: unable to prepare context");
-    println!("status: {}", output.status);
-    println!("stdout: {}", String::from_utf8_lossy(&output.stdout));
-    println!("stderr: {}", String::from_utf8_lossy(&output.stderr));
-    assert!(output.status.success());
+    let docker_build = env::var("DOCKER_BUILD").is_ok();
+    if docker_build {
+        let output = Command::new("docker")
+            .arg("build")
+            .arg("-t")
+            .arg("nym:latest")
+            .arg("-f")
+            .arg("./Dockerfile.nym")
+            .arg(".")
+            .output()
+            .expect("ERROR: unable to prepare context");
+        println!("status: {}", output.status);
+        println!("stdout: {}", String::from_utf8_lossy(&output.stdout));
+        println!("stderr: {}", String::from_utf8_lossy(&output.stderr));
+        assert!(output.status.success());
+    };
 }

--- a/build.rs
+++ b/build.rs
@@ -1,9 +1,8 @@
 use std::env;
 use std::process::Command;
+
 fn main() {
-    println!("cargo:rerun-if-changed=Dockerfile.nym");
-    let docker_build = env::var("DOCKER_BUILD").is_ok();
-    if docker_build {
+    if env::var("DOCKER_BUILD").is_ok() {
         let output = Command::new("docker")
             .arg("build")
             .arg("-t")


### PR DESCRIPTION


## Changes
- This allows devs to bypass the docker build step. Now, the docker image will *only* be built when `DOCKER_BUILD` environment variable is set.`

## Tests
To build the docker image before running tests:
```bash
DOCKER_BUILD=1 cargo test
```
To run tests normally,
```bash
cargo test
```

Note that you *could* use this with `cargo check` and `cargo build` as well, but that doesn't work really.

## Issues

- Closes #10 