### PR TITLE
feat: extract RTT from ping::Success

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 futures = "0.3.26"
 hex = "0.4"
-libp2p = { version = "0.51.0", features = [ "identify", "macros", "ping", "tokio" ]}
+libp2p = { version = "0.51.0", features = [ "identify", "macros", "ping", "tokio", "tcp", "dns", "websocket", "noise", "mplex", "yamux" ]}
 multihash = "0.17"
 nym-websocket = { package = "websocket-requests", git = "https://github.com/nymtech/nym" }
 nym-sphinx = { package = "nym-sphinx", git = "https://github.com/nymtech/nym" }
@@ -22,6 +22,9 @@ tracing-subscriber = "0.2.15"
 
 [dev-dependencies]
 testcontainers = "0.14.0"
+
+[features]
+vanilla = []
 
 [patch.crates-io] 
 libp2p = { git = "https://github.com/ChainSafe/rust-libp2p.git", rev = "e3440d25681df380c9f0f8cfdcfd5ecc0a4f2fb6" }

--- a/README.md
+++ b/README.md
@@ -41,6 +41,18 @@ You should see that the nodes connected and pinged each other:
 # Mar 30 22:56:35.595  INFO ping: BehaviourEvent: Event { peer: PeerId("12D3KooWMd5ak31DXuZq7x1JuFSR6toA5RDQrPaHrfXEhy7vqqpC"), result: Ok(Pong) }
 ```
 
+In order to run the ping example with vanilla libp2p, which uses tcp, pass the
+`--features vanilla` flag to the example and follow the instructions on the
+rust-libp2p project as usual.
+
+```bash
+RUST_LOG=ping=debug cargo run --examples ping --feature vanilla
+```
+
+```bash
+RUST_LOG=ping=debug cargo run --examples ping --feature vanilla -- "/ip4/127.0.0.1/tcp/$PORT"
+```
+
 ### Writing New Tests
 
 In order to abstract away the `nym-client` instantiation, we rely on the
@@ -53,19 +65,12 @@ In order to create a single service, developers can use the following code
 snippet.
 
 ```rust
-#[cfg(test)]
-mod test {
-    use crate::new_nym_client;
-    #[tokio::test]
-    async fn test_with_nym() {
-
-        let nym_id = "test_transport_connection_dialer";
-        #[allow(unused)]
-        let dialer_uri: String;
-        new_nym_client!(nym_id, dialer_uri);
-        todo!("Now you can use the dialer_uri to make requests.")
-    }
-}
+let dialer_uri: String = Default::default();
+rust_libp2p_nym::new_nym_client!(nym_id, dialer_uri);
 ```
 
 One can create as many of these as needed, limited only by the server resources.
+
+For more usage patterns, look at `src/transport.rs`. Note that if the code terminates
+in a non-clean way, you might have to kill the running docker containers
+manually using `docker rm -f $ID".

--- a/examples/ping.rs
+++ b/examples/ping.rs
@@ -40,43 +40,66 @@
 //! The two nodes establish a connection, negotiate the ping protocol
 //! and begin pinging each other.
 
-use libp2p::core::{muxing::StreamMuxerBox, transport::Transport};
 use libp2p::futures::StreamExt;
-use libp2p::swarm::{keep_alive, NetworkBehaviour, SwarmBuilder, SwarmEvent};
+use libp2p::ping::Success;
+use libp2p::swarm::{keep_alive, NetworkBehaviour, SwarmEvent};
 use libp2p::{identity, ping, Multiaddr, PeerId};
-use rust_libp2p_nym::{new_nym_client, transport::NymTransport};
 use std::error::Error;
+use std::time::Duration;
+#[cfg(not(feature = "vanilla"))]
 use testcontainers::{clients, core::WaitFor, images::generic::GenericImage};
-use tracing::info;
+use tracing::{debug, info};
 use tracing_subscriber::EnvFilter;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
     tracing_subscriber::fmt()
         .with_env_filter(
-            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("debug")),
+            EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| EnvFilter::new("ping=debug,rust_libp2p_nym=debug")),
         )
         .init();
-
-    let nym_id = rand::random::<u64>().to_string();
-    #[allow(unused)]
-    let dialer_uri: String = Default::default();
-    new_nym_client!(nym_id, dialer_uri);
 
     let local_key = identity::Keypair::generate_ed25519();
     let local_peer_id = PeerId::from(local_key.public());
     info!("Local peer id: {local_peer_id:?}");
+    #[cfg(not(feature = "vanilla"))]
+    let nym_id = rand::random::<u64>().to_string();
+    #[allow(unused)]
+    #[cfg(not(feature = "vanilla"))]
+    let dialer_uri: String = Default::default();
+    #[cfg(not(feature = "vanilla"))]
+    rust_libp2p_nym::new_nym_client!(nym_id, dialer_uri);
+    #[cfg(not(feature = "vanilla"))]
+    debug!("Launched nym client using docker.");
 
-    let transport = NymTransport::new(&dialer_uri, local_key).await?;
+    #[cfg(not(feature = "vanilla"))]
+    let mut swarm = {
+        debug!("Running `ping` example using NymTransport");
+        use libp2p::core::{muxing::StreamMuxerBox, transport::Transport};
+        use libp2p::swarm::SwarmBuilder;
+        use rust_libp2p_nym::transport::NymTransport;
 
-    let mut swarm = SwarmBuilder::with_tokio_executor(
-        transport
-            .map(|a, _| (a.0, StreamMuxerBox::new(a.1)))
-            .boxed(),
-        Behaviour::default(),
-        local_peer_id,
-    )
-    .build();
+        let transport = NymTransport::new(&dialer_uri, local_key.clone()).await?;
+        SwarmBuilder::with_tokio_executor(
+            transport
+                .map(|a, _| (a.0, StreamMuxerBox::new(a.1)))
+                .boxed(),
+            Behaviour::default(),
+            local_peer_id,
+        )
+        .build()
+    };
+
+    #[cfg(feature = "vanilla")]
+    let mut swarm = {
+        debug!("Running `ping` example using the vanilla libp2p tokio_development_transport");
+        let transport = libp2p::tokio_development_transport(local_key)?;
+        let mut swarm =
+            libp2p::Swarm::with_tokio_executor(transport, Behaviour::default(), local_peer_id);
+        swarm.listen_on("/ip4/0.0.0.0/tcp/0".parse()?)?;
+        swarm
+    };
 
     // Dial the peer identified by the multi-address given as the second
     // command-line argument, if any.
@@ -86,10 +109,31 @@ async fn main() -> Result<(), Box<dyn Error>> {
         info!("Dialed {addr}")
     }
 
+    let mut total_ping_rtt: Duration = Duration::from_micros(0);
+    let mut counter: u128 = 0;
     loop {
         match swarm.select_next_some().await {
             SwarmEvent::NewListenAddr { address, .. } => info!("Listening on {address:?}"),
-            SwarmEvent::Behaviour(event) => info!("{event:?}"),
+            SwarmEvent::Behaviour(event) => {
+                // Get the round-trip duration for the pings.
+                // This value is already captured in the BehaviourEvent::Ping's `Success::Ping`
+                // field.
+                debug!("{event:?}");
+                if let BehaviourEvent::Ping(ping_event) = event {
+                    let result: Success = ping_event.result?;
+                    match result {
+                        Success::Ping { rtt } => {
+                            counter += 1;
+                            total_ping_rtt += rtt;
+                            let average_ping_rtt = Duration::from_micros(
+                                (total_ping_rtt.as_micros() / counter).try_into().unwrap(),
+                            );
+                            info!("Ping RTT: {rtt:?} AVERAGE RTT: ({counter} pings): {average_ping_rtt:?}");
+                        }
+                        Success::Pong => info!("Pong Event"),
+                    }
+                }
+            }
             _ => {}
         }
     }


### PR DESCRIPTION
Reading the `rtt` field from `libp2p::ping::Success::Ping`. This gives us the latency for #17. @noot @clearloop my idea for this is to read these values, average them out and keep outputting the running average on screen (and writing to a file if it makes sense, maybe overkill?)

The ping RTT has increased from `0.5-1 ms` (without nym), to `~1` second (nym transport).


### TODOs

* Need to print out the averages.
* Need to also document the same process for calculating the average latency for the [original ping](https://github.com/libp2p/rust-libp2p/blob/master/examples/ping-example/src/main.rs) example from `libp2p/rust-libp2p`.
