### PR TITLE
chore: explicitly state docker image version

### DIFF
--- a/Dockerfile.nym
+++ b/Dockerfile.nym
@@ -3,6 +3,7 @@ RUN apt-get update -qqq
 RUN apt-get install -y wget ca-certificates build-essential
 RUN apt-get install libssl1.1
 WORKDIR /nym
+# Get the nym binaries from github.
 RUN wget https://github.com/nymtech/nym/releases/download/nym-binaries-v1.1.12/nym-client
 RUN chmod a+rx nym-client && mv nym-client /usr/bin/
 ENV NYM_ID 'default'

--- a/README.md
+++ b/README.md
@@ -4,17 +4,25 @@ This repo contains an implementation of a libp2p transport using the Nym mixnet.
 
 ## Tests
 
-Install `protoc`. On Ubuntu/Debian, run: `sudo apt-get install protobuf-compiler`.
+Install `protoc`. On Ubuntu/Debian, run: `sudo apt-get install
+protobuf-compiler`.
 
-Ensure that docker is installed on the machine where the tests need to be run.
+Ensure that docker is installed on the machine where the tests need to
+be run.
 
 Then, run the following as usual.
+
 ```
 DOCKER_BUILD=1 cargo test
 ```
 
-Note that if you've already built the docker image and want to avoid this step,
-you can ignore the `DOCKER_BUILD` environment variable.
+### Notes on Docker
+
+* If you've already built the docker image and want to avoid this step,
+  you can ignore the `DOCKER_BUILD` environment variable.
+* The Docker image is a *local* image and we are not pushing this
+  anywhere. The tag is reflective of the version of the binaries that
+  we are downloading from github releases for the nym client
 
 ## Ping example
 

--- a/build.rs
+++ b/build.rs
@@ -2,11 +2,15 @@ use std::env;
 use std::process::Command;
 
 fn main() {
+    // NOTE: This builds the Docker container *locally*,
+    // and is not pulling the image from anywhere publically.
+    let docker_image = "chainsafe/nym:1.1.12";
+
     if env::var("DOCKER_BUILD").is_ok() {
         let output = Command::new("docker")
             .arg("build")
             .arg("-t")
-            .arg("nym:latest")
+            .arg(docker_image)
             .arg("-f")
             .arg("./Dockerfile.nym")
             .arg(".")

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -7,7 +7,7 @@ macro_rules! new_nym_client {
     ($nym_id:ident, $uri:ident) => {
         let docker_client = clients::Cli::default();
         let nym_ready_message = WaitFor::message_on_stderr("Client startup finished!");
-        let nym_image = GenericImage::new("nym", "latest")
+        let nym_image = GenericImage::new("chainsafe/nym", "1.1.12")
             .with_env_var("NYM_ID", $nym_id)
             .with_wait_for(nym_ready_message)
             .with_exposed_port(1977);


### PR DESCRIPTION
# Changes

* Clarify how the image is being built by using verbose tags.
* Update docs to have notes about the image.

## Tests


```
DOCKER_BUILD=1 cargo test
```

## Issues

- Fixes #28