### PR TITLE
transport fixes: remove umimplemented errors

### DIFF
--- a/src/transport.rs
+++ b/src/transport.rs
@@ -361,7 +361,7 @@ impl Transport for NymTransport {
 
     fn listen_on(&mut self, _: Multiaddr) -> Result<ListenerId, TransportError<Self::Error>> {
         // we should only allow listening on the multiaddress containing our Nym address
-        Err(TransportError::Other(Error::Unimplemented))
+        Ok(self.listener_id)
     }
 
     fn remove_listener(&mut self, id: ListenerId) -> bool {
@@ -427,9 +427,10 @@ impl Transport for NymTransport {
     // dial_as_listener is unsupported.
     fn dial_as_listener(
         &mut self,
-        _addr: Multiaddr,
+        addr: Multiaddr,
     ) -> Result<Self::Dial, TransportError<Self::Error>> {
-        Err(TransportError::Other(Error::Unimplemented))
+        // Err(TransportError::Other(Error::Unimplemented))
+        self.dial(addr)
     }
 
     fn poll(

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -424,12 +424,11 @@ impl Transport for NymTransport {
         .boxed())
     }
 
-    // dial_as_listener is unsupported.
+    // dial_as_listener currently just calls self.dial().
     fn dial_as_listener(
         &mut self,
         addr: Multiaddr,
     ) -> Result<Self::Dial, TransportError<Self::Error>> {
-        // Err(TransportError::Other(Error::Unimplemented))
         self.dial(addr)
     }
 


### PR DESCRIPTION
## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- for `listen_on`, just return our existing listener id
- for `dial_as_listener`, just return `self.dial()`
- fixes lighthouse integration

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
n/a
```

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

-->

- closes #14